### PR TITLE
fix: logpluginevent block type

### DIFF
--- a/index.helper.ts
+++ b/index.helper.ts
@@ -13,7 +13,7 @@ import slug from 'slug';
 
 import { BotStatsType } from '@/analytics/schemas/bot-stats.schema';
 import EventWrapper from '@/channel/lib/EventWrapper';
-import { BlockFull } from '@/chat/schemas/block.schema';
+import { BlockFull, Block } from '@/chat/schemas/block.schema';
 import { Subscriber } from '@/chat/schemas/subscriber.schema';
 import { Context } from '@/chat/schemas/types/context';
 import { OutgoingMessage } from '@/chat/schemas/types/message';
@@ -537,7 +537,7 @@ export default class InfluxdbHelper
    */
   public logPluginEvent(
     pluginTitle: string,
-    block: BlockFull,
+    block: BlockFull | Block,
     context: Context,
     extraFields: { [key: string]: any },
   ) {

--- a/index.helper.ts
+++ b/index.helper.ts
@@ -13,7 +13,7 @@ import slug from 'slug';
 
 import { BotStatsType } from '@/analytics/schemas/bot-stats.schema';
 import EventWrapper from '@/channel/lib/EventWrapper';
-import { BlockFull, Block } from '@/chat/schemas/block.schema';
+import { Block, BlockFull } from '@/chat/schemas/block.schema';
 import { Subscriber } from '@/chat/schemas/subscriber.schema';
 import { Context } from '@/chat/schemas/types/context';
 import { OutgoingMessage } from '@/chat/schemas/types/message';
@@ -177,7 +177,7 @@ export default class InfluxdbHelper
    */
   private getBlockFields(
     event: EventWrapper<any, any> | null,
-    block: BlockFull,
+    block: BlockFull | Block,
     context?: Context,
   ): InfluxFields {
     const payload = event && event.getPayload();


### PR DESCRIPTION
This PR addresses the issue where the block parameter in logpluginevent() function should be Block type instead of BlockFull type.
The suggested solution is to keep both types to not cause any possible breakdown
Fixes #6 