### PR TITLE
feat: custom subject tagname + add category tagname

### DIFF
--- a/i18n/en/label.json
+++ b/i18n/en/label.json
@@ -4,5 +4,6 @@
   "organization": "Organization",
   "bucket": "Bucket",
   "subjects": "Subjects",
-  "default_subject": "Default Subject"
+  "default_subject": "Default Subject",
+  "subject_tagname": "Tag name for subject (`subject` by default)"
 }

--- a/i18n/fr/label.json
+++ b/i18n/fr/label.json
@@ -4,5 +4,6 @@
   "organization": "Organisation",
   "bucket": "Bucket",
   "subjects": "Sujets",
-  "default_subject": "Sujet par défault"
+  "default_subject": "Sujet par défault",
+  "subject_tagname": "Le nom du tag pour le sujet (`subject` par défaut)"
 }

--- a/index.helper.ts
+++ b/index.helper.ts
@@ -1,9 +1,12 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
- * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
+ * This software is licensed under a proprietary license.
+ * Unauthorized copying, distribution, modification, or use of this software, in whole or in part, is strictly prohibited without prior written permission from Hexastack.
+ *
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
+ * 3. Use of this software is restricted to authorized licensees only and subject to the terms of the licensing agreement provided by Hexastack.
  */
 
 import { InfluxDB, Point } from '@influxdata/influxdb-client';
@@ -383,13 +386,17 @@ export default class InfluxdbHelper
     block: BlockFull,
     context: Context,
   ) {
+    const settings = await this.getSettings();
     const subscriber = event.getSender();
+    const subjectKey = settings.subject_tagname || 'subject';
     const tags = {
       ...this.getMessageTags(event),
       channel: event._handler.getName() || 'unknown',
       type: 'block',
-      subject: await this.getBlockSubject(block.name),
+      [subjectKey]: await this.getBlockSubject(block.name),
+      category: block.category?.label || 'unknown',
     };
+
     const fields: InfluxFields = {
       ...this.getSubscriberFields(subscriber),
       ...this.getBlockFields(event, block, context),

--- a/index.helper.ts
+++ b/index.helper.ts
@@ -1,12 +1,9 @@
 /*
- * Copyright © 2025 Hexastack. All rights reserved.
+ * Copyright © 2024 Hexastack. All rights reserved.
  *
- * This software is licensed under a proprietary license.
- * Unauthorized copying, distribution, modification, or use of this software, in whole or in part, is strictly prohibited without prior written permission from Hexastack.
- *
+ * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
- * 3. Use of this software is restricted to authorized licensees only and subject to the terms of the licensing agreement provided by Hexastack.
  */
 
 import { InfluxDB, Point } from '@influxdata/influxdb-client';

--- a/settings.ts
+++ b/settings.ts
@@ -1,12 +1,9 @@
 /*
- * Copyright © 2025 Hexastack. All rights reserved.
+ * Copyright © 2024 Hexastack. All rights reserved.
  *
- * This software is licensed under a proprietary license.
- * Unauthorized copying, distribution, modification, or use of this software, in whole or in part, is strictly prohibited without prior written permission from Hexastack.
- *
+ * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
- * 3. Use of this software is restricted to authorized licensees only and subject to the terms of the licensing agreement provided by Hexastack.
  */
 
 import { HelperSetting } from '@/helper/types';

--- a/settings.ts
+++ b/settings.ts
@@ -1,9 +1,12 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
- * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
+ * This software is licensed under a proprietary license.
+ * Unauthorized copying, distribution, modification, or use of this software, in whole or in part, is strictly prohibited without prior written permission from Hexastack.
+ *
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
+ * 3. Use of this software is restricted to authorized licensees only and subject to the terms of the licensing agreement provided by Hexastack.
  */
 
 import { HelperSetting } from '@/helper/types';
@@ -24,30 +27,42 @@ export default [
     group: INFLUXDB_HELPER_NAMESPACE,
     label: 'token',
     value: 'mytoken',
-    type: SettingType.text,
+    type: SettingType.secret,
+    translatable: false,
   },
   {
     group: INFLUXDB_HELPER_NAMESPACE,
     label: 'organization',
     value: 'Hexastack',
     type: SettingType.text,
+    translatable: false,
   },
   {
     group: INFLUXDB_HELPER_NAMESPACE,
     label: 'bucket',
     value: 'Hexabot',
     type: SettingType.text,
+    translatable: false,
   },
   {
     group: INFLUXDB_HELPER_NAMESPACE,
     label: 'subjects',
     value: ['Greeting', 'Question', 'Handover'],
     type: SettingType.multiple_text,
+    translatable: false,
   },
   {
     group: INFLUXDB_HELPER_NAMESPACE,
     label: 'default_subject',
     value: 'Other',
     type: SettingType.text,
+    translatable: false,
+  },
+  {
+    group: INFLUXDB_HELPER_NAMESPACE,
+    label: 'subject_tagname',
+    value: 'subject',
+    type: SettingType.text,
+    translatable: false,
   },
 ] as const satisfies HelperSetting<typeof INFLUXDB_HELPER_NAME>[];


### PR DESCRIPTION
This PR introduces a new setting allowing customization of the subject (keyword-based) tag name used in InfluxDB measurements. Previously, the subject tag name was fixed, which could lead to conflicts with other tags — for example, an NLP entity also named subject.

## Changes:
- Added a new configuration setting to define a custom tag name for subject.
- Updated InfluxDB write logic to use the configured tag name instead of a hardcoded value.
- Backward compatibility by defaulting to the existing subject tag name if no custom value is provided.
- Add category tagname